### PR TITLE
Update source code to work with ue5 only

### DIFF
--- a/SteamVRPassthrough/Source/SteamVRPassthrough/Private/SteamVRExternalTexture.cpp
+++ b/SteamVRPassthrough/Source/SteamVRPassthrough/Private/SteamVRExternalTexture.cpp
@@ -117,7 +117,7 @@ void FSteamVRExternalTextureResource::InitRHI()
 		Flags |= TexCreate_SRGB;
 	}
 
-	FRHIResourceCreateInfo CreateInfo;
+	FRHIResourceCreateInfo CreateInfo(TEXT("FSteamVRExternalTextureResource::InitRHI"));
 	Texture2DRHI = RHICreateTexture2D(GetSizeX(), GetSizeY(), Owner->Format, Owner->NumMips, 1, Flags, CreateInfo);
 
 

--- a/SteamVRPassthrough/Source/SteamVRPassthrough/Public/SteamVRPassthroughRendering.h
+++ b/SteamVRPassthrough/Source/SteamVRPassthrough/Public/SteamVRPassthroughRendering.h
@@ -192,20 +192,20 @@ private:
 	FMatrix GetCameraProjection(const uint32 CameraId, const float ZNear, const float ZFar);
 	FMatrix GetCameraProjectionInv(const uint32 CameraId, const float ZNear, const float ZFar);
 	bool GetTrackedCameraEyePoses(FMatrix& LeftPose, FMatrix& RightPose);
-	FMatrix GetHMDRawMVPMatrix(const EStereoscopicPass Eye);
+	FMatrix GetHMDRawMVPMatrix(const EStereoscopicEye Eye);
 	
 	/**
 	 * Returns a matrix that can transform a [-1 to 1] screenspace quad with the camera frame UV mapped it, 
 	 * so that the frame is correctly projected for the view. The right eye UVs need to be shifted by 0.5 horizontally.
 	 */
-	FMatrix GetTrackedCameraQuadTransform(const EStereoscopicPass Eye, const float ProjectionDistanceNear, const float ProjectionDistanceFar);
+	FMatrix GetTrackedCameraQuadTransform(const EStereoscopicEye Eye, const float ProjectionDistanceNear, const float ProjectionDistanceFar);
 
 	/**
 	 * Returns a 3x3 matrix that transforms the screenspace UVs for the camera frame.
 	 * Since the transformation is non-linear in R2, if done in the vertex shader, 
 	 * the output Uvs will need to be passed as homogenous coordinates to the fragment shader.
 	 */
-	FMatrix GetTrackedCameraUVTransform(const EStereoscopicPass Eye, const float ProjectionDistance);
+	FMatrix GetTrackedCameraUVTransform(const EStereoscopicEye Eye, const float ProjectionDistance);
 
 private:
 

--- a/SteamVRPassthrough/Source/SteamVRPassthrough/SteamVRPassthrough.Build.cs
+++ b/SteamVRPassthrough/Source/SteamVRPassthrough/SteamVRPassthrough.Build.cs
@@ -28,6 +28,7 @@ namespace UnrealBuildTool.Rules
 					"CoreUObject",
 					"Engine",
 					"RHI",
+					"RHICore",
 					"RenderCore",
 					"Renderer",
                     "InputCore",


### PR DESCRIPTION
Hello,

Right now this pr references the #3 issue.

This is not a [Add UE5] compatibility but more a, this are the modifications that made the plugins work with UE5.

I think making a list of changes might be more representative than a little explanation :
- SteamVRPassthrough.Build.cs: add RHICore ModuleDependency
- SteamVRExternalTexture.cpp: constructor requires a name, added function name in namespace
- SteamVRPassthroughRendering.cpp: use of RegisterExternalOrPassthroughTexture which has been remove
  -> I checked the source code function and it calls another functions if GraphBuilder is not null and in the plugin it seems to be always valid, thus i replaced it with a RegisterExternalTexture function call
- I updated the shader parameters which seems to require to be strongly typed on the c++ side (FMatrix wont work but FMatrix44f will)
- The biggest change, the **EStereoscopicPass** change. Indeed now there are 2 structs, **EStereoscopicPass** and **EStereoscopicEye**. **EStereoscopicEye** seems to represent the UE4 **EStereoscopicPass** and the informations of left or right eye rendering seems to be the based on **StereoViewIndex**.
  -> for this one i am not 100% sure what I did was right but I looked at the usaged of symbols, functions and fonction of said functions which led me this conclusion (the added GetStereoscopicEyeFromIndex function)

This PR really represent what I changed to get it working, I might have done mistakes or wrong asumptions. I didn't understand the entirerty of the code yet.